### PR TITLE
Bugfix/calibration separation

### DIFF
--- a/drive/drive/calibrate.py
+++ b/drive/drive/calibrate.py
@@ -180,8 +180,9 @@ def config_motor(odrv_num, axis_num, clear, powerDC):
 
 
 
-
+# Get serial numbers of all connected ODrives
 def get_all_odrives():
+    
     # Pull all connected devices ID to the list
     odrivesSerialList = []
     usbDevices = str(subprocess.run(['lsusb', '-v'], capture_output=True).stdout).split('\\n')

--- a/drive/drive/calibration_node.py
+++ b/drive/drive/calibration_node.py
@@ -1,0 +1,74 @@
+# Author: Cameron Rosenthal - @Supernova1114
+
+# ROS2 imports
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+from .calibrate import get_all_odrives, calibrate_all_motors
+
+# General imports
+import sys
+from signal import signal, SIGINT
+
+
+class Calibration_Node(Node):
+
+    # Quit program safely
+    def quit_program_safely(self):
+
+        print("\nExited Safely")
+        sys.exit(0)
+
+
+    # Callback for Ctrl+C
+    def signalHandler(self, signal, frame):
+        self.quit_program_safely()
+
+
+    # Constructor
+    def __init__(self):
+
+        # Signal handler for Ctrl+C
+        signal(SIGINT, self.signalHandler)
+
+        # Give the node a name.
+        super().__init__('drive_calibration_node')
+
+        # Show a yes/no dialog to confirm calibration
+        print("Calibrate ODrives? (y/n)")
+        self.calibrate_odrives = (input() == 'y')
+
+        if self.calibrate_odrives:
+            odrives = get_all_odrives() # Get ODrive serial numbers using linux lsusb
+            odriveCount = len(odrives)
+
+            # Check if ODrives are connected
+            if odriveCount == 0 or odriveCount == 1:
+                print("Not all ODrives connected. Exiting...")
+            else:
+                print("Calibrating ODrives...")
+                calibrate_all_motors(odrives[0], odrives[1])
+        else:
+            print("Skipping ODrive calibration")
+            
+        self.quit_program_safely()
+
+
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    calibration_node = Calibration_Node()
+
+    rclpy.spin(calibration_node)
+
+    # Destroy the node explicitly
+    # (optional - otherwise it will be done automatically
+    # when the garbage collector destroys the node object)
+    calibration_node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/drive/drive/calibration_node.py
+++ b/drive/drive/calibration_node.py
@@ -34,22 +34,15 @@ class Calibration_Node(Node):
         # Give the node a name.
         super().__init__('drive_calibration_node')
 
-        # Show a yes/no dialog to confirm calibration
-        print("Calibrate ODrives? (y/n)")
-        self.calibrate_odrives = (input() == 'y')
+        odrives = get_all_odrives() # Get ODrive serial numbers using linux lsusb
+        odriveCount = len(odrives)
 
-        if self.calibrate_odrives:
-            odrives = get_all_odrives() # Get ODrive serial numbers using linux lsusb
-            odriveCount = len(odrives)
-
-            # Check if ODrives are connected
-            if odriveCount == 0 or odriveCount == 1:
-                print("Not all ODrives connected. Exiting...")
-            else:
-                print("Calibrating ODrives...")
-                calibrate_all_motors(odrives[0], odrives[1])
+        # Check if ODrives are connected
+        if odriveCount == 0 or odriveCount == 1:
+            print("Not all ODrives connected. Exiting...")
         else:
-            print("Skipping ODrive calibration")
+            print("Calibrating ODrives...")
+            calibrate_all_motors(odrives[0], odrives[1])
             
         self.quit_program_safely()
 

--- a/drive/drive/diff_drive_conversion.py
+++ b/drive/drive/diff_drive_conversion.py
@@ -8,7 +8,10 @@ from rclpy.node import Node
 from geometry_msgs.msg import Twist
 from std_msgs.msg import Float64MultiArray
 
+# General imports
 from . import diff_drive_kinematics as ddr
+import sys
+from signal import signal, SIGINT
 
 
 class DiffDriveConversion(Node):
@@ -17,7 +20,21 @@ class DiffDriveConversion(Node):
     # CONSTANTS
     PRINT_TOLERANCE = 0.0001
 
+     # Quit program safely
+    def quit_program_safely(self):
+
+        print("\nExited Safely")
+        sys.exit(0)
+
+    # Callback for Ctrl+C
+    def signalHandler(self, signal, frame):
+        self.quit_program_safely()
+
     def __init__(self):
+
+        # Signal handler for Ctrl+C
+        signal(SIGINT, self.signalHandler)
+
         super().__init__('diff_drive_conversion')
 
         self.last_vel = (0.0, 0.0)

--- a/drive/launch/rover_drive.launch.py
+++ b/drive/launch/rover_drive.launch.py
@@ -23,6 +23,7 @@ def generate_launch_description():
         package='drive',
         executable='diff_drive_conversion',
         output='screen',
+        condition=UnlessCondition(calibrate)
     )
 
     calibration_node = Node(
@@ -36,7 +37,7 @@ def generate_launch_description():
         package='drive',
         executable='motor_driver',
         output='screen',
-        # condition=UnlessCondition(calibrate)
+        condition=UnlessCondition(calibrate)
     )
 
 

--- a/drive/launch/rover_drive.launch.py
+++ b/drive/launch/rover_drive.launch.py
@@ -4,6 +4,9 @@ Launch file for starting drive subsystem on rover.
 
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
+from launch.conditions import IfCondition, UnlessCondition
+from launch.actions import DeclareLaunchArgument
 
 
 def generate_launch_description():
@@ -13,26 +16,38 @@ def generate_launch_description():
     Launches conversion from twist messages to normalized wheel velocities,
     along with motor drivers.
     """
+
+    calibrate = LaunchConfiguration('calibrate')
+
     diff_drive_conversion = Node(
         package='drive',
         executable='diff_drive_conversion',
         output='screen',
     )
 
-    # calibration_node = Node(
-    #     package='drive',
-    #     executable='calibration',
-    #     output='screen',
-    # )
+    calibration_node = Node(
+        package='drive',
+        executable='calibration',
+        output='screen',
+        condition=IfCondition(calibrate),
+    )
 
     motor_driver = Node(
         package='drive',
         executable='motor_driver',
         output='screen',
+        # condition=UnlessCondition(calibrate)
     )
 
+
     return LaunchDescription([
+        
+        DeclareLaunchArgument(
+            'calibrate',
+            default_value='false',
+            description='True to calibrate motors'),
+        
         diff_drive_conversion,
-        # calibration_node,
+        calibration_node,
         motor_driver,
     ])

--- a/drive/launch/rover_drive.launch.py
+++ b/drive/launch/rover_drive.launch.py
@@ -19,6 +19,12 @@ def generate_launch_description():
         output='screen',
     )
 
+    calibration_node = Node(
+        package='drive',
+        executable='calibration',
+        output='screen',
+    )
+
     motor_driver = Node(
         package='drive',
         executable='motor_driver',
@@ -27,5 +33,6 @@ def generate_launch_description():
 
     return LaunchDescription([
         diff_drive_conversion,
+        calibration_node,
         motor_driver,
     ])

--- a/drive/launch/rover_drive.launch.py
+++ b/drive/launch/rover_drive.launch.py
@@ -19,11 +19,11 @@ def generate_launch_description():
         output='screen',
     )
 
-    calibration_node = Node(
-        package='drive',
-        executable='calibration',
-        output='screen',
-    )
+    # calibration_node = Node(
+    #     package='drive',
+    #     executable='calibration',
+    #     output='screen',
+    # )
 
     motor_driver = Node(
         package='drive',
@@ -33,6 +33,6 @@ def generate_launch_description():
 
     return LaunchDescription([
         diff_drive_conversion,
-        calibration_node,
+        # calibration_node,
         motor_driver,
     ])

--- a/drive/setup.py
+++ b/drive/setup.py
@@ -35,6 +35,7 @@ setup(
             f'gamepad_tank_drive = {PKG_NAME}.gamepad_tank_drive:main',
             f'motor_driver = {PKG_NAME}.odrive_motor_driver:main',
             f'diff_drive_conversion = {PKG_NAME}.diff_drive_conversion:main',
+            f'calibration = {PKG_NAME}.calibration_node:main',
         ],
     },
 )


### PR DESCRIPTION
- Only need to calibrate one time after power up of ODrives.
- Runs with launch file and calibrate:=true or calibrate:=false.
- Launch file by default does not run calibration