### PR TITLE
Bugfix/drive heartbeat

### DIFF
--- a/drive/drive/calibration_node.py
+++ b/drive/drive/calibration_node.py
@@ -38,7 +38,7 @@ class Calibration_Node(Node):
         odriveCount = len(odrives)
 
         # Check if ODrives are connected
-        if odriveCount == 0 or odriveCount == 1:
+        if odriveCount != 2:
             print("Not all ODrives connected. Exiting...")
         else:
             print("Calibrating ODrives...")

--- a/drive/drive/calibration_node.py
+++ b/drive/drive/calibration_node.py
@@ -38,7 +38,7 @@ class Calibration_Node(Node):
         odriveCount = len(odrives)
 
         # Check if ODrives are connected
-        if odriveCount != 2:
+        if odriveCount == 0:
             print("Not all ODrives connected. Exiting...")
         else:
             print("Calibrating ODrives...")

--- a/drive/drive/odrive_motor_driver.py
+++ b/drive/drive/odrive_motor_driver.py
@@ -63,7 +63,7 @@ class DriveReceiverSub(Node):
     def quit_program_safely(self):
 
         self.softStop()
-        
+
         print("\nExited Safely")
         sys.exit(0)
 
@@ -93,7 +93,7 @@ class DriveReceiverSub(Node):
         odriveCount = len(odrives)
 
         # Check if ODrives are connected
-        if odriveCount != 2:
+        if odriveCount == 0:
             print("Not all ODrives connected. Exiting...")
             self.quit_program_safely()
         

--- a/drive/drive/odrive_motor_driver.py
+++ b/drive/drive/odrive_motor_driver.py
@@ -163,15 +163,23 @@ class DriveReceiverSub(Node):
     # Signal to stop all motors
     def softStop(self):
         
+        self.close_loop_control()
         self.set_motor_velocity(0, 0)
         self.idle_state()
+
+
+    # Signal to brake all motors
+    def enable_braking(self):
+        
+        self.close_loop_control()
+        self.set_motor_velocity(0, 0)
 
 
     # For safety. Check if controls are being received by subscriber callback
     # Stop motors if subscription not being received.
     def subscription_heartbeat(self):
         if perf_counter() - self.time_of_last_callback > self.signal_timeout:
-            self.softStop()
+            self.enable_braking()
 
 
     # '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -185,10 +193,11 @@ class DriveReceiverSub(Node):
 
         (l_analog, r_analog) = msg.data
 
+        self.close_loop_control()
+
         if l_analog == 0 and r_analog == 0:
             self.set_motor_velocity(0, 0)
         else:
-            self.close_loop_control()
             self.set_motor_velocity(l_analog * self.speed, r_analog * self.speed)
 
         self.voltage_check()

--- a/drive/drive/odrive_motor_driver.py
+++ b/drive/drive/odrive_motor_driver.py
@@ -62,6 +62,8 @@ class DriveReceiverSub(Node):
     # Quit program safely
     def quit_program_safely(self):
 
+        self.softStop()
+        
         print("\nExited Safely")
         sys.exit(0)
 


### PR DESCRIPTION
- Added heartbeat packet for drive subscription.
- If a loss of connection occurs, or drive controls are not received for a set timeout period (2s as of now), rover will stop moving.
- Behavior for heartbeat timeout: active braking.
- Behavior for drive script stop: soft stop.